### PR TITLE
lat,lng precision

### DIFF
--- a/lib/src/projection.dart
+++ b/lib/src/projection.dart
@@ -66,7 +66,7 @@ extension ProjectionExtensions on Projection {
 /// its unique property of representing any course of constant bearing
 /// as a straight segment.
 class EPSG4326 extends Projection {
-  const EPSG4326();
+  const EPSG4326({super.precision});
 
   static const EPSG4326 instance = EPSG4326();
 

--- a/lib/src/projection.dart
+++ b/lib/src/projection.dart
@@ -1,9 +1,7 @@
 part of latlng;
 
 abstract class Projection {
-  const Projection({this.precision = 14});
-
-  final int precision;
+  const Projection();
 
   /// Converts a [LatLng] to its corresponing [TileIndex] screen coordinates.
   TileIndex toTileIndex(LatLng location);
@@ -66,7 +64,9 @@ extension ProjectionExtensions on Projection {
 /// its unique property of representing any course of constant bearing
 /// as a straight segment.
 class EPSG4326 extends Projection {
-  const EPSG4326({super.precision});
+  const EPSG4326({this.precision = 14});
+
+  final int precision;
 
   static const EPSG4326 instance = EPSG4326();
 

--- a/lib/src/projection.dart
+++ b/lib/src/projection.dart
@@ -1,7 +1,9 @@
 part of latlng;
 
 abstract class Projection {
-  const Projection();
+  const Projection({this.precision = 14});
+
+  final int precision;
 
   /// Converts a [LatLng] to its corresponing [TileIndex] screen coordinates.
   TileIndex toTileIndex(LatLng location);
@@ -89,9 +91,16 @@ class EPSG4326 extends Projection {
     final xx = x - 0.5;
     final yy = 0.5 - y;
 
-    final lat = 90.0 - 360.0 * atan(exp(-yy * 2.0 * pi)) / pi;
-    final lng = 360.0 * xx;
+    final lat = _round(90.0 - 360.0 * atan(exp(-yy * 2.0 * pi)) / pi, precision);
+    final lng = _round(360.0 * xx, precision);
 
     return LatLng(lat, lng);
   }
+}
+
+double _round(double value, int precision) {
+  final j = pow(10, precision);
+  value *= j;
+  value = value.toInt() as double;
+  return value / j;
 }


### PR DESCRIPTION
Use case:
When dragging the map, it generates too precise lat, long. For example 107.13222175529222,47.9134491252185. Practically, I needed 7 digits after the dot. Like this: 107.1322217,47.9134491.

Proposal:
Projection.toLatLng() method should round numbers with arbitrary precision. For example in my case 7 digits.

